### PR TITLE
Add --year option, stop hardcoding season_id=2025

### DIFF
--- a/player_universe_load/__main__.py
+++ b/player_universe_load/__main__.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from .db import get_connection, init_schema
@@ -21,8 +22,11 @@ LOAD_DIR = Path("/Users/Shared/BaseballHQ/resources/load")
 FIXTURES_DIR = Path("tests/fixtures")
 
 
-def load_all():
+def load_all(year: int | None = None):
     """Load all data from ETL pipeline or test fixtures into the database."""
+    season_id = year or datetime.now().year
+    print(f"   📅 Season: {season_id}\n")
+
     # Determine which data source to use
     use_pipeline = TRANSFORM_DIR.exists() and LOAD_DIR.exists()
 
@@ -62,7 +66,7 @@ def load_all():
         if hitters_file.exists():
             print(f"   📄 Reading {hitters_file}")
             hitters = json.loads(hitters_file.read_text())
-            counts = load_players(conn, hitters, season_id=2025)
+            counts = load_players(conn, hitters, season_id=season_id)
             print(f"  ✓ Hitters: {counts['players']} players, {counts['batting']} stat records")
             print(f"    {counts['projections']} projections, {counts['valuations']} valuations")
         else:
@@ -71,7 +75,7 @@ def load_all():
         if pitchers_file.exists():
             print(f"   📄 Reading {pitchers_file}")
             pitchers = json.loads(pitchers_file.read_text())
-            counts = load_players(conn, pitchers, season_id=2025)
+            counts = load_players(conn, pitchers, season_id=season_id)
             print(f"  ✓ Pitchers: {counts['players']} players, {counts['pitching']} stat records")
             print(f"    {counts['projections']} projections, {counts['valuations']} valuations")
         else:

--- a/player_universe_load/cli.py
+++ b/player_universe_load/cli.py
@@ -8,7 +8,7 @@ import sys
 from .__main__ import load_all
 
 
-def load_local():
+def load_local(year: int | None = None):
     """Load data to local PostgreSQL database."""
     print("🏠 Loading to LOCAL PostgreSQL database...")
     print("   Connection: postgresql://localhost/fantasy_baseball\n")
@@ -16,7 +16,7 @@ def load_local():
     # Override to use local database
     os.environ["DATABASE_URL"] = "postgresql://localhost/fantasy_baseball"
 
-    load_all()
+    load_all(year=year)
 
 
 def sync_to_neon():
@@ -82,13 +82,13 @@ def sync_to_neon():
     print("✅ Sync to Neon complete!")
 
 
-def load_and_sync():
+def load_and_sync(year: int | None = None):
     """Load to local database and sync to Neon in one command."""
     print("🚀 Full workflow: Load local → Export → Upload to Neon\n")
     print("=" * 60)
 
     # Step 1: Load locally
-    load_local()
+    load_local(year=year)
 
     print("\n" + "=" * 60)
 
@@ -134,13 +134,19 @@ Examples:
         choices=["load-and-sync", "load-local", "sync-to-neon", "verify"],
         help="Command to execute",
     )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=None,
+        help="Season year to stamp on loaded rows (default: current year)",
+    )
 
     args = parser.parse_args()
 
     if args.command == "load-and-sync":
-        load_and_sync()
+        load_and_sync(year=args.year)
     elif args.command == "load-local":
-        load_local()
+        load_local(year=args.year)
     elif args.command == "sync-to-neon":
         sync_to_neon()
     elif args.command == "verify":

--- a/player_universe_load/loaders/players.py
+++ b/player_universe_load/loaders/players.py
@@ -5,7 +5,7 @@ from typing import Any
 from ..db import bulk_insert, json_serialize
 
 
-def load_players(conn, data: list[dict[str, Any]], season_id: int = 2025) -> dict[str, int]:
+def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, int]:
     """Load players, their stats, projections, and valuations."""
     print(f"   📊 Processing {len(data):,} players...", flush=True)
     counts = {"players": 0, "batting": 0, "pitching": 0, "projections": 0, "valuations": 0}


### PR DESCRIPTION
## Summary
- Drop the `season_id: int = 2025` default on `load_players` (now required)
- `load_all()` accepts `year` and defaults to the current year
- Wire `--year` through the CLI for `load-local` and `load-and-sync`

## Why
The input JSON in `resources/load/hitters.json` and `pitchers.json` was current 2026 data, but `__main__.py` hardcoded `season_id=2025` on both `load_players` calls. Every player stat, projection, and valuation row was stamped 2025 in Postgres and pushed to Neon under 2025, silently mixing seasons.

## Test plan
- [x] `load-local --year 2026` runs end-to-end against the current pipeline output
- [x] `SELECT season_id, COUNT(*) FROM player_stats_batting GROUP BY season_id` → only `2026`
- [x] `SELECT season_id, COUNT(*) FROM player_valuations GROUP BY season_id` → only `2026`
- [ ] Default (no `--year`) uses current year via `datetime.now().year`
- [ ] `load-and-sync --year 2026` pushes correctly to Neon

🤖 Generated with [Claude Code](https://claude.com/claude-code)