### PR TITLE
feat: capture new league_name + per-matchup category breakdowns

### DIFF
--- a/player_universe_load/__main__.py
+++ b/player_universe_load/__main__.py
@@ -128,8 +128,9 @@ def load_all(year: int | None = None):
         if schedule_file.exists():
             print(f"   📄 Reading {schedule_file}")
             schedule = json.loads(schedule_file.read_text())
-            count = load_matchups(conn, schedule)
-            print(f"  ✓ Loaded {count} matchups")
+            counts = load_matchups(conn, schedule)
+            print(f"  ✓ Loaded {counts['matchups']} matchups, "
+                  f"{counts['matchup_categories']} category rows")
         else:
             print(f"   ⚠️  Schedule file not found: {schedule_file}")
         print()

--- a/player_universe_load/db.py
+++ b/player_universe_load/db.py
@@ -72,8 +72,18 @@ def init_schema(conn) -> None:
     print("✓ Schema initialized")
 
 
-def bulk_insert(conn, table: str, columns: list[str], rows: list[tuple]) -> int:
-    """Bulk insert rows into table with a Rich progress bar for large inserts."""
+def bulk_insert(
+    conn,
+    table: str,
+    columns: list[str],
+    rows: list[tuple],
+    commit: bool = True,
+) -> int:
+    """Bulk insert rows into table with a Rich progress bar for large inserts.
+
+    commit=False leaves the rows in the open transaction so a caller can
+    group several inserts into one atomic unit and commit them together.
+    """
     if not rows:
         return 0
 
@@ -115,10 +125,12 @@ def bulk_insert(conn, table: str, columns: list[str], rows: list[tuple]) -> int:
                     batch = rows[i : i + batch_size]
                     cur.executemany(sql, batch)
                     progress.update(task, advance=len(batch))
-            conn.commit()
+            if commit:
+                conn.commit()
         else:
             cur.executemany(sql, rows)
-            conn.commit()
+            if commit:
+                conn.commit()
             console.print(
                 f"   [green]✓[/green] Inserted [bold]{len(rows):,}[/bold] rows into "
                 f"[cyan]{table}[/cyan]"

--- a/player_universe_load/exporters/parquet.py
+++ b/player_universe_load/exporters/parquet.py
@@ -37,13 +37,14 @@ logger = logging.getLogger(__name__)
 
 PARQUET_DIR = Path("/Users/Shared/BaseballHQ/resources/analytics")
 
-# Matches the 12-table schema in player_universe_load/schemas/.
+# Mirrors the schema in player_universe_load/schemas/ (minus parquet_artifacts).
 # Add a new entry here when a new table is added to the schema.
 EXPORTED_TABLES: tuple[str, ...] = (
     "players",
     "leagues",
     "teams",
     "matchups",
+    "matchup_categories",
     "roster_slots",
     "league_scoring_categories",
     "player_fantasy_assignments",

--- a/player_universe_load/loaders/leagues.py
+++ b/player_universe_load/loaders/leagues.py
@@ -13,6 +13,7 @@ def load_league(conn, data: dict[str, Any]) -> dict[str, int]:
     league_row = (
         data["league_id"],
         data["season_id"],
+        data.get("league_name"),
         data.get("scoring_period_id"),
         data.get("num_teams"),
         data.get("acquisition_budget"),
@@ -21,7 +22,7 @@ def load_league(conn, data: dict[str, Any]) -> dict[str, int]:
     )
 
     counts["leagues"] = bulk_insert(conn, "leagues",
-        ["league_id", "season_id", "scoring_period_id", "num_teams",
+        ["league_id", "season_id", "league_name", "scoring_period_id", "num_teams",
          "acquisition_budget", "draft_auction_budget", "roster_settings"],
         [league_row]
     )

--- a/player_universe_load/loaders/matchups.py
+++ b/player_universe_load/loaders/matchups.py
@@ -52,16 +52,21 @@ def load_matchups(conn, data: dict[str, Any]) -> dict[str, int]:
                     cat.get("result"),
                 ))
 
+    # Insert both with commit=False, then commit once: a matchup and its
+    # child category rows must land atomically. A failure in the second
+    # insert otherwise leaves matchups committed without their categories,
+    # and the caller's rollback() can no longer restore the schedule.
     counts = {
         "matchups": bulk_insert(conn, "matchups",
             ["matchup_id", "league_id", "season_id", "period_id", "is_playoff",
              "is_bye_week", "team1_id", "team1_score", "team2_id",
              "team2_score", "winner_id"],
-            matchup_rows
+            matchup_rows, commit=False
         ),
         "matchup_categories": bulk_insert(conn, "matchup_categories",
             ["matchup_id", "team_id", "category", "value", "result"],
-            category_rows
+            category_rows, commit=False
         ),
     }
+    conn.commit()
     return counts

--- a/player_universe_load/loaders/matchups.py
+++ b/player_universe_load/loaders/matchups.py
@@ -5,13 +5,19 @@ from typing import Any
 from ..db import bulk_insert
 
 
-def load_matchups(conn, data: dict[str, Any]) -> int:
-    """Load matchups from schedule data."""
+def load_matchups(conn, data: dict[str, Any]) -> dict[str, int]:
+    """Load matchups and their per-category result breakdowns.
+
+    Returns counts for both the matchups rows and the child
+    matchup_categories rows.
+    """
     matchup_rows = []
+    category_rows = []
 
     for matchup in data.get("matchups", []):
+        matchup_id = matchup["matchup_id"]
         matchup_rows.append((
-            matchup["matchup_id"],
+            matchup_id,
             data["league_id"],
             data["season_id"],
             matchup["period_id"],
@@ -24,8 +30,38 @@ def load_matchups(conn, data: dict[str, Any]) -> int:
             matchup.get("winner_id"),
         ))
 
-    return bulk_insert(conn, "matchups",
-        ["matchup_id", "league_id", "season_id", "period_id", "is_playoff",
-         "is_bye_week", "team1_id", "team1_score", "team2_id", "team2_score", "winner_id"],
-        matchup_rows
-    )
+        if matchup.get("is_bye_week"):
+            # Bye weeks carry no category contest. Emit one sentinel row so
+            # every matchup is represented in matchup_categories — downstream
+            # joins/aggregations never silently miss a bye matchup.
+            category_rows.append(
+                (matchup_id, matchup.get("team1_id"), "BYE", None, "BYE")
+            )
+            continue
+
+        # Played matchups carry team1_categories / team2_categories arrays;
+        # future unplayed matchups carry neither, so emit no category rows.
+        for side in ("team1", "team2"):
+            team_id = matchup.get(f"{side}_id")
+            for cat in matchup.get(f"{side}_categories", []):
+                category_rows.append((
+                    matchup_id,
+                    team_id,
+                    cat["category"],
+                    cat.get("value"),
+                    cat.get("result"),
+                ))
+
+    counts = {
+        "matchups": bulk_insert(conn, "matchups",
+            ["matchup_id", "league_id", "season_id", "period_id", "is_playoff",
+             "is_bye_week", "team1_id", "team1_score", "team2_id",
+             "team2_score", "winner_id"],
+            matchup_rows
+        ),
+        "matchup_categories": bulk_insert(conn, "matchup_categories",
+            ["matchup_id", "team_id", "category", "value", "result"],
+            category_rows
+        ),
+    }
+    return counts

--- a/player_universe_load/schemas/02_leagues.sql
+++ b/player_universe_load/schemas/02_leagues.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS leagues CASCADE;
 CREATE TABLE leagues (
     league_id INTEGER PRIMARY KEY,
     season_id INTEGER NOT NULL,
+    league_name VARCHAR(100),
     scoring_period_id INTEGER,
     num_teams INTEGER,
     acquisition_budget INTEGER,

--- a/player_universe_load/schemas/15_matchup_categories.sql
+++ b/player_universe_load/schemas/15_matchup_categories.sql
@@ -1,0 +1,21 @@
+-- Matchup Categories Table
+-- Per-category result breakdown for each team in a matchup. One row per
+-- (matchup, team, category). Mirrors the player_valuations ->
+-- player_valuation_details split: a child table normalizing the repeating
+-- category records that arrive nested in the schedule JSON.
+-- Bye-week matchups carry a single sentinel row (category = 'BYE').
+DROP TABLE IF EXISTS matchup_categories CASCADE;
+
+CREATE TABLE matchup_categories (
+    id SERIAL PRIMARY KEY,
+    matchup_id INTEGER NOT NULL REFERENCES matchups(matchup_id) ON DELETE CASCADE,
+    team_id INTEGER REFERENCES teams(team_id),
+    category VARCHAR(20) NOT NULL,
+    value NUMERIC,
+    result VARCHAR(10),
+    UNIQUE(matchup_id, team_id, category)
+);
+
+CREATE INDEX idx_matchup_categories_matchup ON matchup_categories(matchup_id);
+CREATE INDEX idx_matchup_categories_team ON matchup_categories(team_id);
+CREATE INDEX idx_matchup_categories_category ON matchup_categories(category);

--- a/player_universe_load/validation/schema_validator.py
+++ b/player_universe_load/validation/schema_validator.py
@@ -42,6 +42,63 @@ PLAYER_COLUMNS = [
 BATTING_STAT_COLUMNS = ["player_id", "season_id", "stat_period"] + list(BATTING_DB_COLUMNS)
 PITCHING_STAT_COLUMNS = ["player_id", "season_id", "stat_period"] + list(PITCHING_DB_COLUMNS)
 
+# Top-level keys the league summary loader (loaders/leagues.py) consumes.
+LEAGUE_SUMMARY_KEYS = {
+    "league_id",
+    "season_id",
+    "league_name",
+    "scoring_period_id",
+    "num_teams",
+    "acquisition_budget",
+    "draft_auction_budget",
+    "roster_settings",
+    "scoring_categories",
+}
+
+# Per-matchup keys the schedule loader (loaders/matchups.py) consumes.
+MATCHUP_KEYS = {
+    "matchup_id",
+    "period_id",
+    "is_playoff",
+    "is_bye_week",
+    "team1_id",
+    "team1_score",
+    "team2_id",
+    "team2_score",
+    "winner_id",
+    "team1_categories",
+    "team2_categories",
+}
+
+
+def _warn_unknown_keys(fixtures_dir: Path) -> None:
+    """Soft-warn when upstream league files carry keys no loader consumes.
+
+    Unlike the table-column checks this never raises: a new upstream field
+    should not break a load, but it must not vanish silently either. The
+    loaders pull fields by name, so an unrecognized key is data the pipeline
+    is dropping on the floor — surface it so the schema can catch up.
+    """
+    for summary_file in sorted(fixtures_dir.glob("league_*_summary.json")):
+        data = json.loads(summary_file.read_text())
+        unknown = set(data) - LEAGUE_SUMMARY_KEYS
+        if unknown:
+            print(
+                f"   ⚠️  {summary_file.name}: unhandled key(s) "
+                f"{sorted(unknown)} — not loaded into `leagues`"
+            )
+
+    for schedule_file in sorted(fixtures_dir.glob("league_*_schedule.json")):
+        data = json.loads(schedule_file.read_text())
+        unknown: set[str] = set()
+        for matchup in data.get("matchups", []):
+            unknown |= set(matchup) - MATCHUP_KEYS
+        if unknown:
+            print(
+                f"   ⚠️  {schedule_file.name}: unhandled matchup key(s) "
+                f"{sorted(unknown)} — not loaded into `matchups`"
+            )
+
 
 def validate_data_schema(conn, fixtures_dir: Path) -> bool:
     """
@@ -100,6 +157,9 @@ def validate_data_schema(conn, fixtures_dir: Path) -> bool:
                     schema_issues.append(
                         ("player_stats_pitching", missing, extra)
                     )
+
+    # Soft-warn on upstream league/matchup keys no loader consumes.
+    _warn_unknown_keys(fixtures_dir)
 
     # Report issues
     if schema_issues:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -311,6 +311,92 @@ def test_validate_data_schema_mismatch_raises_with_extra_cols(tmp_path: Path, ca
         conn.close()
 
 
+def test_warn_unknown_keys_flags_drift(tmp_path: Path, capsys):
+    """_warn_unknown_keys surfaces upstream keys no loader consumes.
+
+    Fixtures carry no drift, so CI never exercises the warning branches —
+    this test makes them deterministic.
+    """
+    fdir = tmp_path / "drift"
+    fdir.mkdir()
+    (fdir / "league_10998_summary.json").write_text(
+        json.dumps(
+            {"league_id": 10998, "season_id": 2026, "brand_new_field": "x"}
+        )
+    )
+    (fdir / "league_10998_schedule.json").write_text(
+        json.dumps(
+            {
+                "league_id": 10998,
+                "season_id": 2026,
+                "matchups": [
+                    {"matchup_id": 1, "period_id": 1, "surprise_key": True}
+                ],
+            }
+        )
+    )
+    schema_validator._warn_unknown_keys(fdir)
+    out = capsys.readouterr().out
+    assert "brand_new_field" in out
+    assert "surprise_key" in out
+
+
+def test_warn_unknown_keys_silent_when_clean(tmp_path: Path, capsys):
+    """No warning when every key is handled."""
+    fdir = tmp_path / "clean"
+    fdir.mkdir()
+    (fdir / "league_10998_summary.json").write_text(
+        json.dumps({"league_id": 10998, "season_id": 2026})
+    )
+    schema_validator._warn_unknown_keys(fdir)
+    assert "unhandled" not in capsys.readouterr().out
+
+
+# -------------------- loaders/matchups.py --------------------
+
+
+def test_load_matchups_flattens_categories_and_bye_placeholder():
+    """load_matchups flattens teamN_categories into child rows and emits a
+    bye sentinel. Fixtures lack team*_categories, so CI never hits the
+    category-append line without this test."""
+    from player_universe_load.loaders.matchups import load_matchups
+
+    schedule = {
+        "league_id": 10998,
+        "season_id": 2026,
+        "matchups": [
+            {
+                "matchup_id": 90001,
+                "period_id": 1,
+                "is_bye_week": False,
+                "team1_id": 1,
+                "team1_score": "2-1-0",
+                "team2_id": 7,
+                "team2_score": "1-2-0",
+                "winner_id": 1,
+                "team1_categories": [
+                    {"category": "HR", "value": 9.0, "result": "WIN"},
+                    {"category": "ERA", "value": 3.1, "result": "LOSS"},
+                ],
+                "team2_categories": [
+                    {"category": "HR", "value": 4.0, "result": "LOSS"},
+                ],
+            },
+            {
+                "matchup_id": 90002,
+                "period_id": 1,
+                "is_bye_week": True,
+                "team1_id": 8,
+                "team1_score": "0-0-0",
+            },
+        ],
+    }
+    counts = load_matchups(MagicMock(), schedule)
+    assert counts["matchups"] == 2
+    # 2 team1 + 1 team2 category rows, plus 1 bye sentinel row.
+    assert counts["matchup_categories"] == 4
+
+
 # -------------------- __main__.py --------------------
 
 


### PR DESCRIPTION
## Why

Upstream league files shifted — two new fields appeared that the schema had no home for. The loaders pull fields by name via `dict.get()`, so the new keys were dropped **silently** while `load-local` still reported success.

| New upstream field | File | Was |
|---|---|---|
| `league_name` | `league_10998_summary.json` | dropped |
| `team1_categories` / `team2_categories` | `league_10998_schedule.json` | dropped |

`team*_categories` = 12 `{category, value, result}` records per team per played matchup (per-category WIN/LOSS/TIE breakdown).

## What

- **`leagues`**: add `league_name VARCHAR(100)` column + load it
- **New `matchup_categories` table**: one row per `(matchup, team, category)`, mirroring the existing `player_valuations` → `player_valuation_details` split. Normalized rather than JSONB so **DuckDB downstream** reads `value` as a native `NUMERIC` column with predicate pushdown — not `json_extract` over a JSON-encoded string (parquet export JSON-string-encodes JSONB).
- **`matchups` loader**: flattens `teamN_categories` into child rows; bye-week matchups get one sentinel row (`category='BYE'`) so every matchup stays represented downstream. `load_matchups` now returns a count dict.
- **Parquet exporter**: registers `matchup_categories` (13th artifact).
- **Schema validator**: soft-warns on future unhandled league/matchup keys so the next silent-drop is surfaced, not lost.

## Verification

- `load-local`: loads `league_name` + **974** `matchup_categories` rows = 40 played × 24 + **14 bye placeholders**
- `export-parquets`: emits `matchup_categories.parquet`; DuckDB reads `value` as `decimal`, `category`/`result` as `varchar`
- **10/10 tests pass**

## Migration notes

- Neon: no separate migration — `sync-to-neon` does `pg_dump --clean --if-exists` full dump/restore, picks up the new table + column automatically.
- 30 future unplayed non-bye matchups (0-0-0) get **0** category rows by design — only byes get a placeholder. Flag if those should be covered.
- `tests/fixtures/league_10998_*.json` still carry the old shape (harmless — `.get()` → `None`); a fixture refresh would exercise the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)