### PR TITLE
feat: load games-started limits/tally + roster eligibility dates

### DIFF
--- a/player_universe_load/loaders/leagues.py
+++ b/player_universe_load/loaders/leagues.py
@@ -9,6 +9,11 @@ def load_league(conn, data: dict[str, Any]) -> dict[str, int]:
     """Load league summary and scoring categories."""
     counts = {"leagues": 0, "scoring_categories": 0}
 
+    # Games-started limits (pitcher start-cap rule). Absent upstream for
+    # leagues with no start cap; `or {}` lets every .get() below fall through
+    # to None so the league still loads.
+    gsl = data.get("games_started_limits") or {}
+
     # Insert league
     league_row = (
         data["league_id"],
@@ -19,11 +24,17 @@ def load_league(conn, data: dict[str, Any]) -> dict[str, int]:
         data.get("acquisition_budget"),
         data.get("draft_auction_budget"),
         json_serialize(data.get("roster_settings")),
+        gsl.get("stat_id"),
+        gsl.get("min"),
+        gsl.get("max_per_scoring_period"),
+        gsl.get("max_per_matchup"),
     )
 
     counts["leagues"] = bulk_insert(conn, "leagues",
         ["league_id", "season_id", "league_name", "scoring_period_id", "num_teams",
-         "acquisition_budget", "draft_auction_budget", "roster_settings"],
+         "acquisition_budget", "draft_auction_budget", "roster_settings",
+         "gsl_stat_id", "gsl_min", "gsl_max_per_scoring_period",
+         "gsl_max_per_matchup"],
         [league_row]
     )
 

--- a/player_universe_load/loaders/matchups.py
+++ b/player_universe_load/loaders/matchups.py
@@ -16,6 +16,12 @@ def load_matchups(conn, data: dict[str, Any]) -> dict[str, int]:
 
     for matchup in data.get("matchups", []):
         matchup_id = matchup["matchup_id"]
+        # Per-team games-started tally (pitcher start cap). Absent upstream
+        # for leagues with no start cap; `or {}` lets each .get() fall
+        # through to None. One fixed-shape object per side, so it flattens
+        # into team1_/team2_ columns like team1_score/team2_score.
+        t1_gs = matchup.get("team1_games_started") or {}
+        t2_gs = matchup.get("team2_games_started") or {}
         matchup_rows.append((
             matchup_id,
             data["league_id"],
@@ -28,6 +34,12 @@ def load_matchups(conn, data: dict[str, Any]) -> dict[str, int]:
             matchup.get("team2_id"),
             matchup.get("team2_score"),
             matchup.get("winner_id"),
+            t1_gs.get("value"),
+            t1_gs.get("limit_exceeded"),
+            t1_gs.get("exceeded_on_scoring_period"),
+            t2_gs.get("value"),
+            t2_gs.get("limit_exceeded"),
+            t2_gs.get("exceeded_on_scoring_period"),
         ))
 
         if matchup.get("is_bye_week"):
@@ -60,7 +72,11 @@ def load_matchups(conn, data: dict[str, Any]) -> dict[str, int]:
         "matchups": bulk_insert(conn, "matchups",
             ["matchup_id", "league_id", "season_id", "period_id", "is_playoff",
              "is_bye_week", "team1_id", "team1_score", "team2_id",
-             "team2_score", "winner_id"],
+             "team2_score", "winner_id",
+             "team1_gs_value", "team1_gs_limit_exceeded",
+             "team1_gs_exceeded_on_scoring_period",
+             "team2_gs_value", "team2_gs_limit_exceeded",
+             "team2_gs_exceeded_on_scoring_period"],
             matchup_rows, commit=False
         ),
         "matchup_categories": bulk_insert(conn, "matchup_categories",

--- a/player_universe_load/loaders/teams.py
+++ b/player_universe_load/loaders/teams.py
@@ -82,6 +82,7 @@ def load_team_roster(conn, data: dict[str, Any]) -> dict[str, int]:
                 player.get("acquisition_type"),
                 acquisition_date,
                 player.get("keeper_value"),
+                json_serialize(player.get("eligible_date_by_position")),
             ))
 
             # Fantasy assignment
@@ -98,7 +99,8 @@ def load_team_roster(conn, data: dict[str, Any]) -> dict[str, int]:
     if roster_rows:
         counts["roster_slots"] = bulk_insert(conn, "roster_slots",
             ["team_id", "league_id", "season_id", "player_id", "lineup_slot",
-             "acquisition_type", "acquisition_date", "keeper_value"],
+             "acquisition_type", "acquisition_date", "keeper_value",
+             "eligible_date_by_position"],
             roster_rows
         )
 

--- a/player_universe_load/schemas/02_leagues.sql
+++ b/player_universe_load/schemas/02_leagues.sql
@@ -10,6 +10,14 @@ CREATE TABLE leagues (
     acquisition_budget INTEGER,
     draft_auction_budget INTEGER,
     roster_settings JSONB,
+    -- Games-started limits: the league's pitcher start-cap rule. Flattened
+    -- from the trx GamesStartedLimitsModel (one fixed-shape object per
+    -- league), so the four scalars become columns rather than JSONB or a
+    -- child table. All NULL for leagues with no start cap.
+    gsl_stat_id INTEGER,
+    gsl_min NUMERIC,
+    gsl_max_per_scoring_period NUMERIC,
+    gsl_max_per_matchup NUMERIC,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/player_universe_load/schemas/05_matchups.sql
+++ b/player_universe_load/schemas/05_matchups.sql
@@ -13,6 +13,16 @@ CREATE TABLE matchups (
     team2_id INTEGER REFERENCES teams(team_id),
     team2_score VARCHAR(20),
     winner_id INTEGER REFERENCES teams(team_id),
+    -- Per-team games-started tally (pitcher start cap). Flattened from the
+    -- trx GamesStartedModel, one fixed-shape object per side — mirrors the
+    -- existing team1_/team2_ score pair. All NULL for leagues with no
+    -- start cap (trx omits the field when absent).
+    team1_gs_value NUMERIC,
+    team1_gs_limit_exceeded BOOLEAN,
+    team1_gs_exceeded_on_scoring_period INTEGER,
+    team2_gs_value NUMERIC,
+    team2_gs_limit_exceeded BOOLEAN,
+    team2_gs_exceeded_on_scoring_period INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/player_universe_load/schemas/06_roster_slots.sql
+++ b/player_universe_load/schemas/06_roster_slots.sql
@@ -11,6 +11,10 @@ CREATE TABLE roster_slots (
     acquisition_type VARCHAR(20),
     acquisition_date TIMESTAMP,
     keeper_value INTEGER,
+    -- Position name -> ISO date the player became eligible at that position.
+    -- Variable-key map (positions differ per player), so JSONB rather than
+    -- columns. Flattened from the trx RosterSlotPlayer.eligible_date_by_position.
+    eligible_date_by_position JSONB,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(team_id, player_id, season_id)

--- a/player_universe_load/validation/schema_validator.py
+++ b/player_universe_load/validation/schema_validator.py
@@ -73,9 +73,53 @@ MATCHUP_KEYS = {
     "team2_games_started",
 }
 
+# Roster files (team_*_roster.json) are single-team objects. The 11 position
+# fields each hold a list (or single) of roster-player objects.
+ROSTER_POSITION_FIELDS = (
+    "c", "first_base", "second_base", "third_base", "shortstop", "util",
+    "outfield", "sp", "rp", "bench", "injured_list",
+)
+
+# Top-level keys the team loader (loaders/teams.py) consumes.
+ROSTER_KEYS = {
+    "league_id",
+    "season_id",
+    "team_id",
+    "team_name",
+    "team_abbrev",
+    "team_logo",
+    "owners",
+    "primary_owner",
+    "record",
+    "transactions",
+    *ROSTER_POSITION_FIELDS,
+}
+
+# Per-roster-player keys. Broader than what the loader stores: bio fields
+# (name, pro_team, jersey, ...) are intentionally skipped because they
+# FK-join from `players`. This is the full known shape of trx's
+# RosterSlotPlayer, so the warning fires only on a genuinely new key.
+ROSTER_PLAYER_KEYS = {
+    "player_id",
+    "name",
+    "first_name",
+    "last_name",
+    "pro_team",
+    "primary_position",
+    "eligible_positions",
+    "lineup_slot",
+    "acquisition_type",
+    "acquisition_date",
+    "injury_status",
+    "active",
+    "keeper_value",
+    "jersey",
+    "eligible_date_by_position",
+}
+
 
 def _warn_unknown_keys(fixtures_dir: Path) -> None:
-    """Soft-warn when upstream league files carry keys no loader consumes.
+    """Soft-warn when upstream league/roster files carry keys no loader consumes.
 
     Unlike the table-column checks this never raises: a new upstream field
     should not break a load, but it must not vanish silently either. The
@@ -100,6 +144,35 @@ def _warn_unknown_keys(fixtures_dir: Path) -> None:
             print(
                 f"   ⚠️  {schedule_file.name}: unhandled matchup key(s) "
                 f"{sorted(unknown)} — not loaded into `matchups`"
+            )
+
+    # Roster files drift at two levels: the team object and the per-player
+    # objects nested in the position fields. The per-player level is the one
+    # that bit us (eligible_date_by_position was silently dropped), so check
+    # both — the team loader scans roster files but never warned on them.
+    for roster_file in sorted(fixtures_dir.glob("team_*_roster.json")):
+        data = json.loads(roster_file.read_text())
+        unknown_top = set(data) - ROSTER_KEYS
+        if unknown_top:
+            print(
+                f"   ⚠️  {roster_file.name}: unhandled key(s) "
+                f"{sorted(unknown_top)} — not loaded into `teams`"
+            )
+
+        unknown_player: set[str] = set()
+        for field in ROSTER_POSITION_FIELDS:
+            players = data.get(field)
+            if players is None:
+                continue
+            if not isinstance(players, list):
+                players = [players]
+            for player in players:
+                if isinstance(player, dict):
+                    unknown_player |= set(player) - ROSTER_PLAYER_KEYS
+        if unknown_player:
+            print(
+                f"   ⚠️  {roster_file.name}: unhandled roster-player key(s) "
+                f"{sorted(unknown_player)} — not loaded into `roster_slots`"
             )
 
 

--- a/player_universe_load/validation/schema_validator.py
+++ b/player_universe_load/validation/schema_validator.py
@@ -53,6 +53,7 @@ LEAGUE_SUMMARY_KEYS = {
     "draft_auction_budget",
     "roster_settings",
     "scoring_categories",
+    "games_started_limits",
 }
 
 # Per-matchup keys the schedule loader (loaders/matchups.py) consumes.
@@ -68,6 +69,8 @@ MATCHUP_KEYS = {
     "winner_id",
     "team1_categories",
     "team2_categories",
+    "team1_games_started",
+    "team2_games_started",
 }
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -341,12 +341,53 @@ def test_warn_unknown_keys_flags_drift(tmp_path: Path, capsys):
     assert "surprise_key" in out
 
 
+def test_warn_unknown_keys_flags_roster_drift(tmp_path: Path, capsys):
+    """_warn_unknown_keys surfaces unrecognized roster keys at both the team
+    and per-player level. Roster files were unscanned before this — the
+    eligible_date_by_position drift slipped through silently."""
+    fdir = tmp_path / "roster_drift"
+    fdir.mkdir()
+    (fdir / "team_1_roster.json").write_text(
+        json.dumps(
+            {
+                "team_id": 1,
+                "league_id": 10998,
+                "season_id": 2026,
+                "mystery_team_field": 1,
+                "c": [
+                    {
+                        "player_id": 5,
+                        "lineup_slot": "C",
+                        "mystery_player_field": "x",
+                    }
+                ],
+                # Single-player position (not a list) is normalized too.
+                "util": {"player_id": 9, "lineup_slot": "UTIL"},
+            }
+        )
+    )
+    schema_validator._warn_unknown_keys(fdir)
+    out = capsys.readouterr().out
+    assert "mystery_team_field" in out
+    assert "mystery_player_field" in out
+
+
 def test_warn_unknown_keys_silent_when_clean(tmp_path: Path, capsys):
     """No warning when every key is handled."""
     fdir = tmp_path / "clean"
     fdir.mkdir()
     (fdir / "league_10998_summary.json").write_text(
         json.dumps({"league_id": 10998, "season_id": 2026})
+    )
+    (fdir / "team_1_roster.json").write_text(
+        json.dumps(
+            {
+                "team_id": 1,
+                "league_id": 10998,
+                "season_id": 2026,
+                "c": [{"player_id": 5, "lineup_slot": "C"}],
+            }
+        )
     )
     schema_validator._warn_unknown_keys(fdir)
     assert "unhandled" not in capsys.readouterr().out

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -397,6 +397,129 @@ def test_load_matchups_flattens_categories_and_bye_placeholder():
     assert counts["matchup_categories"] == 4
 
 
+def test_load_matchups_flattens_games_started():
+    """load_matchups flattens team*_games_started into matchup columns and
+    falls through to None when a matchup carries no start-cap tally.
+    Fixtures carry no start cap, so CI never hits these .get() lines."""
+    from player_universe_load.loaders import matchups as matchups_mod
+
+    schedule = {
+        "league_id": 10998,
+        "season_id": 2026,
+        "matchups": [
+            {
+                "matchup_id": 90010,
+                "period_id": 1,
+                "team1_id": 1,
+                "team2_id": 7,
+                "team1_games_started": {
+                    "value": 11.0,
+                    "limit_exceeded": True,
+                    "exceeded_on_scoring_period": 4,
+                },
+                "team2_games_started": {
+                    "value": 8.0,
+                    "limit_exceeded": False,
+                    "exceeded_on_scoring_period": 0,
+                },
+            },
+            # No games_started keys -> all six GS columns fall through to None.
+            {"matchup_id": 90011, "period_id": 1, "team1_id": 8, "team2_id": 17},
+        ],
+    }
+    with patch.object(
+        matchups_mod, "bulk_insert", side_effect=lambda *a, **k: len(a[3])
+    ) as bi:
+        matchups_mod.load_matchups(MagicMock(), schedule)
+
+    # First bulk_insert call is the matchups table.
+    _, table, columns, rows = bi.call_args_list[0].args
+    assert table == "matchups"
+    capped = dict(zip(columns, rows[0]))
+    assert capped["team1_gs_value"] == 11.0
+    assert capped["team1_gs_limit_exceeded"] is True
+    assert capped["team1_gs_exceeded_on_scoring_period"] == 4
+    assert capped["team2_gs_value"] == 8.0
+    assert capped["team2_gs_limit_exceeded"] is False
+    no_cap = dict(zip(columns, rows[1]))
+    assert no_cap["team1_gs_value"] is None
+    assert no_cap["team2_gs_exceeded_on_scoring_period"] is None
+
+
+# -------------------- loaders/leagues.py --------------------
+
+
+def test_load_league_flattens_games_started_limits():
+    """load_league flattens games_started_limits into league columns.
+    Fixtures carry no start cap, so CI never hits these .get() lines."""
+    from player_universe_load.loaders import leagues as leagues_mod
+
+    summary = {
+        "league_id": 10998,
+        "season_id": 2026,
+        "games_started_limits": {
+            "stat_id": 99,
+            "min": None,
+            "max_per_scoring_period": 12.0,
+            "max_per_matchup": 6.0,
+        },
+    }
+    with patch.object(
+        leagues_mod, "bulk_insert", side_effect=lambda *a, **k: len(a[3])
+    ) as bi:
+        leagues_mod.load_league(MagicMock(), summary)
+
+    # No scoring_categories key -> only the leagues insert fires.
+    _, table, columns, rows = bi.call_args_list[0].args
+    assert table == "leagues"
+    row = dict(zip(columns, rows[0]))
+    assert row["gsl_stat_id"] == 99
+    assert row["gsl_min"] is None
+    assert row["gsl_max_per_scoring_period"] == 12.0
+    assert row["gsl_max_per_matchup"] == 6.0
+
+
+# -------------------- loaders/teams.py --------------------
+
+
+def test_load_team_roster_captures_eligible_date_by_position():
+    """load_team_roster flattens eligible_date_by_position into a JSONB
+    column and falls through to None when a roster player lacks it."""
+    from player_universe_load.loaders import teams as teams_mod
+
+    roster = {
+        "team_id": 1,
+        "league_id": 10998,
+        "season_id": 2026,
+        "team_name": "Test",
+        "c": [
+            {
+                "player_id": 5016968,
+                "lineup_slot": "C",
+                "eligible_date_by_position": {
+                    "2B": "2026-01-27T07:16:39.933000Z",
+                    "DH": "2026-01-27T07:16:39.933000Z",
+                },
+            },
+            # No eligible_date_by_position -> column falls through to None.
+            {"player_id": 999, "lineup_slot": "C"},
+        ],
+    }
+    with patch.object(
+        teams_mod, "bulk_insert", side_effect=lambda *a, **k: len(a[3])
+    ) as bi:
+        teams_mod.load_team_roster(MagicMock(), roster)
+
+    roster_call = next(c for c in bi.call_args_list if c.args[1] == "roster_slots")
+    _, _, columns, rows = roster_call.args
+    by_player = {
+        dict(zip(columns, r))["player_id"]: dict(zip(columns, r)) for r in rows
+    }
+    edbp = json.loads(by_player[5016968]["eligible_date_by_position"])
+    assert edbp["2B"].startswith("2026-01-27")
+    assert by_player[999]["eligible_date_by_position"] is None
+
+
 # -------------------- __main__.py --------------------
 
 


### PR DESCRIPTION
## What

The trx layer's latest league extract added four models — `EspnGamesStartedModel` / `GamesStartedModel` (per-team start tally within a matchup) and `EspnGamesStartedLimitsModel` / `GamesStartedLimitsModel` (the league's pitcher start-cap rule) — plus `eligible_date_by_position` on `RosterSlotPlayer`. None had a landing spot in the load layer, so the fields were silently dropped on ingest. This wires them through schema → loaders → validator.

## Schema changes

`init_schema` drops and recreates every table each load (and `sync-to-neon` does `pg_dump --clean`), so editing the `schemas/*.sql` files **is** the migration — no `ALTER TABLE`.

| Table | New columns | Shape rationale |
|---|---|---|
| `leagues` | `gsl_stat_id`, `gsl_min`, `gsl_max_per_scoring_period`, `gsl_max_per_matchup` | One fixed-shape object per league → flat columns |
| `matchups` | `team{1,2}_gs_value`, `team{1,2}_gs_limit_exceeded`, `team{1,2}_gs_exceeded_on_scoring_period` | One object per team per matchup → flat columns mirroring the existing `team1_`/`team2_` score pair |
| `roster_slots` | `eligible_date_by_position` (JSONB) | Variable-key position→date map → JSONB, matching the `eligible_slots` / `birth_place` / `roster_settings` pattern |

`jersey` was **not** added to `roster_slots`: it is a static player-bio attribute already captured on `players.jersey`, and `roster_slots` is a thin link table that skips every other bio field. Adding it would duplicate one fact in two tables.

## Loader / validator

- `loaders/leagues.py`, `matchups.py`, `teams.py` read every new field with `.get()` / `or {}`. Leagues with no start cap (trx omits the keys entirely) still load, with the new columns `NULL`.
- `validation/schema_validator.py`: `_warn_unknown_keys` now recognizes `games_started_limits`, `team{1,2}_games_started` so they are not flagged as dropped.

## Testing

- `pytest tests/` — 92 passed (3 new tests covering the flatten paths for all three loaders; fixtures carry no start cap, so CI would otherwise never exercise them).
- Full pipeline run: `load-local` (players 3403, matchups 84, matchup_categories 974, roster_slots 295 with 252 carrying eligibility dates) → `parquet-and-sync` → `verify-r2` (14/14 ok) → `sync-to-neon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)