### PR TITLE
feat: split Savant data into player_pitch_arsenal + player_savant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,14 +273,27 @@ All tables have foreign keys for Hasura auto-relationship detection.
    - ~70 stat columns (ERA, WHIP, K, SV, etc.)
 
 **Analytics:**
-10. **player_projections** - FanGraphs projections
+10. **player_projections** - FanGraphs projections (fangraphs-only)
     - Foreign key: `player_id`
     - Stored as JSONB for flexibility
+    - Source `stats.fangraphs.{projections,projs_updated,ros}`
 
-11. **player_valuations** - Fantasy value calculations
+11. **player_savant** - Baseball Savant observed metric blobs (JSONB)
+    - Foreign key: `player_id`
+    - One row per `(player, season, metric, player_type)`
+    - Metrics: `statcast`, `home_runs`, `sprint_speed`, `swing_take`,
+      `expected_statistics` (source `stats.savant.*`)
+
+12. **player_pitch_arsenal** - Per-pitch Savant data, fully unwrapped (typed)
+    - Foreign key: `player_id`
+    - One row per `(player, season, player_type, pitch_type)`
+    - 32 typed columns (usage%, AVG, whiff%, run_value, percentile ranks…)
+    - Source `stats.savant.pitch_arsenal` (list)
+
+13. **player_valuations** - Fantasy value calculations
     - Foreign keys: `player_id`, `league_id` (optional)
 
-12. **player_valuation_details** - Per-category z-scores/dollars
+14. **player_valuation_details** - Per-category z-scores/dollars
     - Foreign key: `valuation_id`
 
 ### Key Schema Features

--- a/docs/savant_data_contract.md
+++ b/docs/savant_data_contract.md
@@ -1,0 +1,131 @@
+# Savant Data Contract (Hasura ingestion)
+
+Contract for the two Baseball Savant tables introduced when savant data was
+split out of `player_projections`: **`player_pitch_arsenal`** (typed) and
+**`player_savant`** (JSONB blobs). Source for both is `stats.savant.*` in the
+loader input (`hitters.json` / `pitchers.json`).
+
+> **Why two tables:** `pitch_arsenal` is a *list* (one row per pitch type) with
+> a stable, batter/pitcher-identical schema → fully typed. The other five
+> metrics are one-row-per-player dicts with wide, season-variable keys → JSONB,
+> which absorbs Savant field drift without schema churn. `player_projections`
+> is now **fangraphs-only** (genuine projections).
+
+All observed (measured) data — **not** projections.
+
+---
+
+## Relationships to track in Hasura
+
+Both tables FK `player_id → players(id_espn)`. Hasura auto-suggests:
+
+| Relationship | Type | On |
+|---|---|---|
+| `players.player_pitch_arsenal` | array | `players.id_espn → player_pitch_arsenal.player_id` |
+| `players.player_savant` | array | `players.id_espn → player_savant.player_id` |
+| `player_pitch_arsenal.player` | object | reverse |
+| `player_savant.player` | object | reverse |
+
+After a `sync-to-neon`, reload Hasura metadata, then **Track** both tables and
+accept the suggested relationships.
+
+---
+
+## Table: `player_pitch_arsenal`
+
+One typed row per **(player_id, season_id, player_type, pitch_type)**.
+`player_type` = `pitcher` (pitches thrown) or `hitter` (pitches faced) — same
+schema for both. `UNIQUE(player_id, season_id, player_type, pitch_type)`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int (PK) | serial |
+| `player_id` | int (FK) | → players.id_espn |
+| `season_id` | int | |
+| `player_type` | text | `pitcher` \| `hitter` |
+| `pitch_type` | text | code, e.g. `FF`, `SL`, `CH`, `ST`, `SI`, `FS` |
+| `pitch_name` | text | e.g. `4-Seam Fastball` |
+| `pitches` | int | count |
+| `pitch_usage_pct` | numeric | |
+| `PA` | int | |
+| `AVG`, `SLG`, `wOBA` | numeric | against this pitch |
+| `xAVG`, `xSLG`, `xwOBA` | numeric | expected; `xAVG`/`xSLG` nullable |
+| `K_pct`, `whiff_pct`, `put_away_pct`, `hardhit_pct` | numeric | `hardhit_pct` nullable |
+| `run_value` | int | |
+| `run_value_per_100` | numeric | per 100 pitches |
+| `*_pct_rnk` (16 cols) | numeric | Savant percentile rank (0–100) for each metric above |
+| `created_at`, `updated_at` | timestamp | |
+
+GraphQL is fully typed — filter/sort/aggregate without JSON parsing:
+
+```graphql
+query NastiestPitches {
+  player_pitch_arsenal(
+    where: { player_type: { _eq: "pitcher" }, pitches: { _gte: 100 } }
+    order_by: { whiff_pct: desc }
+    limit: 10
+  ) {
+    pitch_name
+    whiff_pct
+    run_value_per_100
+    player { name pro_team }
+  }
+}
+```
+
+---
+
+## Table: `player_savant`
+
+One row per **(player_id, season_id, metric, player_type)**; payload in JSONB
+`data`. `UNIQUE(player_id, season_id, metric, player_type)`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int (PK) | serial |
+| `player_id` | int (FK) | → players.id_espn |
+| `season_id` | int | |
+| `metric` | text | discriminator (see below) |
+| `player_type` | text | `pitcher` \| `hitter` |
+| `data` | jsonb | metric payload |
+| `created_at`, `updated_at` | timestamp | |
+
+`metric` populations:
+
+| metric | population | `data` keys |
+|---|---|---|
+| `statcast` | both | 32 — `bbe, avg_launch_angle, sweetspot_pct, max_ev, avg_ev, ev50, fbld_ev, gb_ev, max_distance, avg_distance, avg_hr_distance, ev95_plus, ev95_pct, barrels, barrels_per_bbe_pct, barrels_per_pa_pct` + matching `*_pct_rnk` |
+| `home_runs` | both | 18 — `year, hr_type, HR, xHR, xHRdiff, avg_hr_trot, doubters, mostly_gone, no_doubters, no_doubter_pct` + `*_pct_rnk` |
+| `swing_take` | both | 16 — `year, team_id, PA, pitches, runs_all, runs_heart, runs_shadow, runs_chase, runs_waste` + `*_pct_rnk` |
+| `sprint_speed` | **hitter-only** | 11 — `age, position, sprint_speed, hp_to_1b, bolts, competitive_runs, team_id` + `*_pct_rnk` |
+| `expected_statistics` | **pitcher-only** | 29 — `year, PA, BIP, AVG, xAVG, xAVGdiff, SLG, xSLG, xSLGdiff, wOBA, xwOBA, wOBAdiff, ERA, xERA, xERAdiff` + `*_pct_rnk` |
+
+`data` is heterogeneous JSON — Hasura exposes it as `jsonb`. Query a metric and
+read fields client-side, or use Postgres `->>` in a view if you need typed
+columns for a specific metric:
+
+```graphql
+query Barrels {
+  player_savant(
+    where: { metric: { _eq: "statcast" }, player_type: { _eq: "hitter" } }
+  ) {
+    player { name }
+    data   # { barrels_per_pa_pct, avg_ev, max_ev, ... }
+  }
+}
+```
+
+> **Parquet / R2 note:** in the parquet artifacts the `data` column is a JSON
+> **string** (not a struct) — `JSON.parse` it on the consumer. All NUMERIC
+> columns in `player_pitch_arsenal` are emitted as `float64` (browser/WASM
+> parquet readers can't decode `decimal128`). See `exporters/parquet.py`.
+
+---
+
+## Discoverability note
+
+If you're looking for `pitch_arsenal` and can't find it: it is **no longer**
+in `player_projections`. It is the typed `player_pitch_arsenal` table. The
+other savant metrics are rows in `player_savant` keyed by `metric`.
+`player_projections` now contains only fangraphs projections
+(`preseason` / `updated` / `ros`).

--- a/player_universe_load/exporters/parquet.py
+++ b/player_universe_load/exporters/parquet.py
@@ -56,6 +56,8 @@ EXPORTED_TABLES: tuple[str, ...] = (
     "player_stats_batting",
     "player_stats_pitching",
     "player_projections",
+    "player_savant",
+    "player_pitch_arsenal",
     "player_valuations",
     "player_valuation_details",
     "position_summary",

--- a/player_universe_load/loaders/players.py
+++ b/player_universe_load/loaders/players.py
@@ -34,13 +34,30 @@ FANGRAPHS_PERIOD_LABELS = {
     "projs_updated": "updated",
     "ros": "ros",
 }
+# Savant metrics kept as one-row-per-player JSONB blobs in player_savant.
+# pitch_arsenal is NOT here — it's a list at a different grain, unwrapped into
+# the typed player_pitch_arsenal table (see ARSENAL_FIELDS).
 SAVANT_BLOB_PERIODS = (
     "statcast",
     "home_runs",
     "sprint_speed",
     "swing_take",
     "expected_statistics",
-    "pitch_arsenal",
+)
+
+# stats.savant.pitch_arsenal is a list of per-pitch dicts with this fixed
+# 32-field schema (identical for pitchers/hitters). Column order here is the
+# insert order for player_pitch_arsenal; names match the source keys exactly.
+ARSENAL_FIELDS = (
+    "pitch_type", "pitch_name", "pitches", "pitch_usage_pct",
+    "PA", "AVG", "SLG", "wOBA", "xAVG", "xSLG", "xwOBA",
+    "K_pct", "whiff_pct", "put_away_pct", "hardhit_pct",
+    "run_value", "run_value_per_100",
+    "pitches_pct_rnk", "pitch_usage_pct_pct_rnk", "PA_pct_rnk",
+    "AVG_pct_rnk", "SLG_pct_rnk", "wOBA_pct_rnk", "xAVG_pct_rnk",
+    "xSLG_pct_rnk", "xwOBA_pct_rnk", "K_pct_pct_rnk", "whiff_pct_pct_rnk",
+    "put_away_pct_pct_rnk", "hardhit_pct_pct_rnk", "run_value_pct_rnk",
+    "run_value_per_100_pct_rnk",
 )
 
 # Stat-key markers used to infer player_type when the explicit marker is
@@ -281,12 +298,15 @@ def _build_pitching_row(player_id: int, season_id: int, period: str, stats: dict
 
 def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, int]:
     """Load players, their stats, projections, and valuations."""
-    counts = {"players": 0, "batting": 0, "pitching": 0, "projections": 0, "valuations": 0}
+    counts = {"players": 0, "batting": 0, "pitching": 0, "projections": 0,
+              "savant": 0, "pitch_arsenal": 0, "valuations": 0}
 
     player_rows = []
     batting_rows = []
     pitching_rows = []
     projection_rows = []
+    savant_rows = []
+    arsenal_rows = []
     valuation_rows = []
     valuation_detail_rows = []
 
@@ -361,18 +381,27 @@ def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, 
                 json_serialize(proj),
             ))
 
+        ptype = "hitter" if player_type == "batter" else "pitcher"
+
+        # Savant descriptive blobs -> player_savant (observed stats, JSONB).
         for savant_blob_key in SAVANT_BLOB_PERIODS:
             blob = savant.get(savant_blob_key)
             if not blob:
                 continue
-            projection_rows.append((
+            savant_rows.append((
                 player["id_espn"],
                 season_id,
-                "savant",
                 savant_blob_key,
-                "hitter" if player_type == "batter" else "pitcher",
+                ptype,
                 json_serialize(blob),
             ))
+
+        # pitch_arsenal -> player_pitch_arsenal, one typed row per pitch.
+        for pitch in savant.get("pitch_arsenal") or []:
+            arsenal_rows.append(
+                (player["id_espn"], season_id, ptype)
+                + tuple(pitch.get(f) for f in ARSENAL_FIELDS)
+            )
 
         # Valuations: dict of scenario -> {primary_position, tier, total_z, total_dollars, z_scores, dollar_values}
         # Scenarios: preseason, updated, ros, synthetic, current
@@ -409,7 +438,8 @@ def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, 
     console.print(
         f"   [dim]📝 Prepared {len(player_rows):,} players, "
         f"{len(batting_rows):,} batting, {len(pitching_rows):,} pitching, "
-        f"{len(projection_rows):,} projections, {len(valuation_rows):,} valuations[/dim]"
+        f"{len(projection_rows):,} projections, {len(savant_rows):,} savant, "
+        f"{len(arsenal_rows):,} pitch_arsenal, {len(valuation_rows):,} valuations[/dim]"
     )
 
     counts["players"] = bulk_insert(conn, "players", [
@@ -436,6 +466,18 @@ def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, 
         counts["projections"] = bulk_insert(conn, "player_projections",
             ["player_id", "season_id", "projection_source", "projection_period", "player_type", "projections"],
             projection_rows
+        )
+
+    if savant_rows:
+        counts["savant"] = bulk_insert(conn, "player_savant",
+            ["player_id", "season_id", "metric", "player_type", "data"],
+            savant_rows
+        )
+
+    if arsenal_rows:
+        counts["pitch_arsenal"] = bulk_insert(conn, "player_pitch_arsenal",
+            ["player_id", "season_id", "player_type"] + list(ARSENAL_FIELDS),
+            arsenal_rows
         )
 
     if valuation_rows:

--- a/player_universe_load/schemas/16_player_pitch_arsenal.sql
+++ b/player_universe_load/schemas/16_player_pitch_arsenal.sql
@@ -1,0 +1,55 @@
+-- Player Pitch Arsenal
+-- Baseball Savant pitch-arsenal data, fully unwrapped from the source
+-- stats.savant.pitch_arsenal list into one typed row per (player, pitch_type).
+-- player_type distinguishes pitches THROWN (pitcher) from pitches FACED
+-- (hitter); both share an identical 32-field schema. Observed data, not a
+-- projection — this previously lived (un-typed) in player_projections under
+-- projection_source='savant', projection_period='pitch_arsenal'.
+DROP TABLE IF EXISTS player_pitch_arsenal CASCADE;
+
+CREATE TABLE player_pitch_arsenal (
+    id SERIAL PRIMARY KEY,
+    player_id INTEGER NOT NULL REFERENCES players(id_espn) ON DELETE CASCADE,
+    season_id INTEGER NOT NULL,
+    player_type VARCHAR(10) NOT NULL,
+    pitch_type VARCHAR(10) NOT NULL,
+    pitch_name VARCHAR(40),
+    pitches INTEGER,
+    pitch_usage_pct NUMERIC,
+    "PA" INTEGER,
+    "AVG" NUMERIC,
+    "SLG" NUMERIC,
+    "wOBA" NUMERIC,
+    "xAVG" NUMERIC,
+    "xSLG" NUMERIC,
+    "xwOBA" NUMERIC,
+    "K_pct" NUMERIC,
+    whiff_pct NUMERIC,
+    put_away_pct NUMERIC,
+    hardhit_pct NUMERIC,
+    run_value INTEGER,
+    run_value_per_100 NUMERIC,
+    -- Savant percentile ranks (0-100) for each metric above.
+    pitches_pct_rnk NUMERIC,
+    pitch_usage_pct_pct_rnk NUMERIC,
+    "PA_pct_rnk" NUMERIC,
+    "AVG_pct_rnk" NUMERIC,
+    "SLG_pct_rnk" NUMERIC,
+    "wOBA_pct_rnk" NUMERIC,
+    "xAVG_pct_rnk" NUMERIC,
+    "xSLG_pct_rnk" NUMERIC,
+    "xwOBA_pct_rnk" NUMERIC,
+    "K_pct_pct_rnk" NUMERIC,
+    whiff_pct_pct_rnk NUMERIC,
+    put_away_pct_pct_rnk NUMERIC,
+    hardhit_pct_pct_rnk NUMERIC,
+    run_value_pct_rnk NUMERIC,
+    run_value_per_100_pct_rnk NUMERIC,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(player_id, season_id, player_type, pitch_type)
+);
+
+CREATE INDEX idx_pitch_arsenal_player ON player_pitch_arsenal(player_id);
+CREATE INDEX idx_pitch_arsenal_season ON player_pitch_arsenal(season_id);
+CREATE INDEX idx_pitch_arsenal_pitch_type ON player_pitch_arsenal(pitch_type);

--- a/player_universe_load/schemas/16_player_savant.sql
+++ b/player_universe_load/schemas/16_player_savant.sql
@@ -1,0 +1,31 @@
+-- Player Savant Metrics
+-- Baseball Savant (Statcast) descriptive metric blobs kept as JSONB:
+--   statcast, home_runs, sprint_speed, swing_take, expected_statistics.
+-- These are one-row-per-player dicts with stable but wide, season-variable
+-- key sets — JSONB absorbs Savant's field drift without schema churn. The
+-- pitch_arsenal metric is split out into its own typed table
+-- (player_pitch_arsenal) because it is a list at a different grain.
+--
+-- All are OBSERVED stats, not projections — they previously lived in
+-- player_projections under projection_source='savant', which mislabeled
+-- measured data as forecasts. player_projections is now fangraphs-only.
+--
+-- sprint_speed is hitter-only and expected_statistics pitcher-only in the
+-- source; the absent population simply has no row for that metric.
+DROP TABLE IF EXISTS player_savant CASCADE;
+
+CREATE TABLE player_savant (
+    id SERIAL PRIMARY KEY,
+    player_id INTEGER NOT NULL REFERENCES players(id_espn) ON DELETE CASCADE,
+    season_id INTEGER NOT NULL,
+    metric VARCHAR(50) NOT NULL,
+    player_type VARCHAR(10) NOT NULL,
+    data JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(player_id, season_id, metric, player_type)
+);
+
+CREATE INDEX idx_savant_player ON player_savant(player_id);
+CREATE INDEX idx_savant_season ON player_savant(season_id);
+CREATE INDEX idx_savant_metric ON player_savant(metric);

--- a/tests/test_load_integration.py
+++ b/tests/test_load_integration.py
@@ -62,11 +62,47 @@ def test_load_all_fixtures():
             assert roster_count > 0, "Should have roster slots"
             print(f"✓ {roster_count} roster slots loaded")
 
-            # Test projections loaded
+            # Test projections loaded — now fangraphs-only; savant moved out.
             cur.execute("SELECT COUNT(*) FROM player_projections")
             proj_count = cur.fetchone()[0]
             assert proj_count > 0, "Should have projections"
             print(f"✓ {proj_count} projections loaded")
+
+            cur.execute(
+                "SELECT DISTINCT projection_source FROM player_projections"
+            )
+            sources = {r[0] for r in cur.fetchall()}
+            assert sources == {"fangraphs"}, (
+                f"player_projections must be fangraphs-only, got {sources}"
+            )
+
+            # Test savant blob metrics loaded into their own table
+            cur.execute("SELECT COUNT(*) FROM player_savant")
+            savant_count = cur.fetchone()[0]
+            assert savant_count > 0, "Should have savant metrics"
+            cur.execute("SELECT DISTINCT metric FROM player_savant")
+            metrics = {r[0] for r in cur.fetchall()}
+            assert "pitch_arsenal" not in metrics, (
+                "pitch_arsenal belongs in player_pitch_arsenal, not player_savant"
+            )
+            assert metrics <= {
+                "statcast", "home_runs", "sprint_speed",
+                "swing_take", "expected_statistics",
+            }, f"unexpected savant metric(s): {metrics}"
+            print(f"✓ {savant_count} savant blob rows loaded ({len(metrics)} metrics)")
+
+            # Test pitch arsenal unwrapped into typed rows (one per pitch type)
+            cur.execute("SELECT COUNT(*) FROM player_pitch_arsenal")
+            arsenal_count = cur.fetchone()[0]
+            assert arsenal_count > 0, "Should have pitch arsenal rows"
+            # Typed columns are populated, not null-collapsed.
+            cur.execute(
+                "SELECT pitch_type, pitches, pitch_usage_pct FROM player_pitch_arsenal "
+                "WHERE pitches IS NOT NULL LIMIT 1"
+            )
+            row = cur.fetchone()
+            assert row and row[0] and row[1] > 0, "arsenal row should have typed values"
+            print(f"✓ {arsenal_count} pitch_arsenal rows loaded")
 
             # Test valuations loaded
             cur.execute("SELECT COUNT(*) FROM player_valuations")


### PR DESCRIPTION
## Problem

`stats.savant.*` is **observed Statcast data**, but the loader filed it into `player_projections` under `projection_source='savant'` — labeling measured data as forecasts. It was undiscoverable (you'd look under "stats", find nothing; the data hid under "projections").

## Change

Two correctly-modeled tables, split by grain + shape:

| Table | Grain | Storage | Holds |
|-------|-------|---------|-------|
| `player_pitch_arsenal` | one row per (player, season, player_type, **pitch_type**) | **typed columns** (32 fields) | `stats.savant.pitch_arsenal` (a list) |
| `player_savant` | one row per (player, season, **metric**, player_type) | JSONB `data` | `statcast`, `home_runs`, `sprint_speed`, `swing_take`, `expected_statistics` |

**Why this split (not full unwrap, not all-blob):**
- `pitch_arsenal` is a list of uniform 32-key dicts with an **identical batter/pitcher schema** → typing it buys SQL filter/sort (usage%, whiff%, run_value, percentile ranks) with zero JSON parsing.
- The other five are one-row-per-player dicts with wide, **season-variable** key sets → JSONB absorbs Savant's field drift without schema churn.
- `player_projections` is now **fangraphs-only** — genuine projections.

`player_type` carries the hitter/pitcher discriminator; `sprint_speed` is hitter-only and `expected_statistics` pitcher-only (absent population simply has no row).

## Notes
- New schema files (`16_player_pitch_arsenal.sql`, `16_player_savant.sql`) sort before `16_views.sql`, so tables are created before any view — no renumbering.
- Both tables added to the parquet exporter (NUMERIC→float64, JSONB→JSON string, per the existing browser-readable encoding).
- FKs to `players(id_espn)` give Hasura auto-relationships.

## Verification
- Load against real data: `player_pitch_arsenal` 3537 rows / 910 players (typed columns confirmed), `player_savant` 3047 rows / 5 metrics, `player_projections` now `{fangraphs}` only.
- Full suite green (95 passed). Integration tests assert new tables populate + `player_projections` carries no savant; parquet row-count test auto-covers the new tables.

A data contract doc for Hasura ingestion follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)