### PR TITLE
feat: add news JSONB column to players table

### DIFF
--- a/player_universe_load/loaders/players.py
+++ b/player_universe_load/loaders/players.py
@@ -340,6 +340,7 @@ def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, 
             player.get("injured"),
             player.get("active"),
             player.get("jersey"),
+            json_serialize(player.get("news")),
         ))
 
         # Stats: stats.{espn,fangraphs,savant}.{period}
@@ -447,7 +448,8 @@ def load_players(conn, data: list[dict[str, Any]], season_id: int) -> dict[str, 
         "name_ascii", "slug", "fangraphs_api_route", "headshot", "primary_position",
         "eligible_slots", "pro_team", "weight", "display_weight", "height",
         "display_height", "bats", "throws", "date_of_birth", "birth_place",
-        "debut_year", "injury_status", "status", "injured", "active", "jersey"
+        "debut_year", "injury_status", "status", "injured", "active", "jersey",
+        "news"
     ], player_rows)
 
     if batting_rows:

--- a/player_universe_load/schemas/01_players.sql
+++ b/player_universe_load/schemas/01_players.sql
@@ -29,6 +29,7 @@ CREATE TABLE players (
     injured BOOLEAN,
     active BOOLEAN,
     jersey INTEGER,
+    news JSONB,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/player_universe_load/validation/schema_validator.py
+++ b/player_universe_load/validation/schema_validator.py
@@ -36,6 +36,7 @@ PLAYER_COLUMNS = [
     "injured",
     "active",
     "jersey",
+    "news",
 ]
 
 # Sourced from the spec in loaders/players.py to avoid drift.


### PR DESCRIPTION
## Summary

- Adds `news JSONB` column to `players` table (after `jersey`)
- Inserts `json_serialize(player.get("news"))` in player loader
- Adds `"news"` to `PLAYER_COLUMNS` in schema validator to prevent false "unused column" warnings

## Depends on

- [Player_Universe_Trx #25](https://github.com/MTBLL/Player_Universe_Trx/pull/25) — passes news through transform pipeline (merged)
- ESPN_API_Extractor #20 — fetches Rotowire news items (merged)

## News data shape

Each item in `player.news`:
```json
{
  "id": 100803110,
  "headline": "Witt (knee) is back in the lineup...",
  "description": "...",
  "story": "Full Rotowire analysis paragraph...",
  "published": "2026-06-09T20:31:21Z",
  "type": "Rotowire"
}
```

Always present (`[]` when no news). Max 5 items per player.

## Validation

- 3,414/3,414 players populated after full load-and-sync with news-carrying extract
- 95/95 tests pass
- `load-and-sync` ran clean end-to-end (local → parquets → R2 → Neon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)